### PR TITLE
Create separate CosmosDB container for the output

### DIFF
--- a/csharp/CosmosEmbeddingGenerator.cs
+++ b/csharp/CosmosEmbeddingGenerator.cs
@@ -44,7 +44,7 @@ namespace CosmosEmbeddingGenerator
         [Function(nameof(CosmosEmbeddingGeneratorFunction))]
         [CosmosDBOutput(
             databaseName: "%COSMOS_DATABASE_NAME%",
-            containerName: "%COSMOS_CONTAINER_NAME%",
+            containerName: "%COSMOS_OUTPUT_CONTAINER_NAME%",
             Connection = "COSMOS_CONNECTION")]
         public async Task<object?> Run(
             [CosmosDBTrigger(

--- a/python/function_app.py
+++ b/python/function_app.py
@@ -35,7 +35,7 @@ app = func.FunctionApp()
 @app.cosmos_db_output(
     arg_name="output", 
     database_name="%COSMOS_DATABASE_NAME%", 
-    container_name="%COSMOS_CONTAINER_NAME%", 
+    container_name="%COSMOS_OUTPUT_CONTAINER_NAME%", 
     connection="COSMOS_CONNECTION")
 @app.cosmos_db_trigger(
     arg_name="input", 

--- a/python/infra/app/database.bicep
+++ b/python/infra/app/database.bicep
@@ -5,7 +5,7 @@ param tags object = {}
 
 param accountName string
 param databaseName string
-param containerName string
+param containerNames array
 param partitionKeyName string
 param vectorPropertyName string
 
@@ -18,8 +18,7 @@ var partitionKeyPath = '/${partitionKeyName}'
 var vectorPath = '/${vectorPropertyName}'
 var vectorExcludedIndexPath = '${vectorPath}/?'
 
-var containers = [
-  {
+var containers = [for containerName in containerNames:{
     name: containerName // Container for products
     partitionKeyPaths: [
       partitionKeyPath // Partition for product data

--- a/python/infra/main.bicep
+++ b/python/infra/main.bicep
@@ -53,6 +53,7 @@ var deploymentStorageContainerName = 'app-package-container'
 var cosmosSettings = {
   database: 'embeddings-generator-db'
   container: 'customer'
+  outputcontainer: 'customer-embeddings'
   partitionKey: 'customerId'
   vectorProperty: 'vectors'
   hashProperty: 'hash'
@@ -125,6 +126,7 @@ module functions 'app/functions.bicep' = {
     appSettings: {
       COSMOS_DATABASE_NAME: cosmosSettings.database
       COSMOS_CONTAINER_NAME: cosmosSettings.container
+      COSMOS_OUTPUT_CONTAINER_NAME: cosmosSettings.outputcontainer
       COSMOS_VECTOR_PROPERTY: cosmosSettings.vectorProperty
       COSMOS_HASH_PROPERTY: cosmosSettings.hashProperty
       COSMOS_PROPERTY_TO_EMBED: cosmosSettings.PropertyToEmbed
@@ -146,7 +148,7 @@ module database 'app/database.bicep' = {
     location: location
     tags: tags
     databaseName: cosmosSettings.database
-    containerName: cosmosSettings.container
+    containerNames: [cosmosSettings.container, cosmosSettings.outputcontainer]
     partitionKeyName: cosmosSettings.partitionKey
     vectorPropertyName: cosmosSettings.vectorProperty
   }


### PR DESCRIPTION
Adds different container for the embeddings, called customer-embeddings, to be used as the output of the function app.