### PR TITLE
Fixes to enable local inner loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,7 @@ This sample shows how to use a Cosmos DB Trigger and Output Binding in Azure Fun
 
 1. Open a terminal and navigate to where you would like to clone this solution
 
-1. Run the following command to download the solution locally to your machine:
-
-   ```bash
-   azd init -t AzureCosmosDB/cosmosdb-embeddings-generator
-   ```
-
-1. From the terminal, navigate to either the csharp or python directory in this solution.
-
-1. Then navigate to the /infra directory.
-
-1. Log in to AZD.
-
-   ```bash
-   azd auth login
-   ```
+1. From the terminal, navigate to either the `csharp` or `python` directory in this solution.
 
 1. Provision the Azure services, build your local solution container, and deploy the application.
 
@@ -46,22 +32,44 @@ OPENAI_ENDPOINT: "https://{my-open-ai-account}.openai.azure.com/"
 
 1. Copy the `sample.settings.json` file into a new file `local.settings.json` in the same folder (csharp or python).  
 
-1. Replace the placeholder values like `OPENAI_ENDPOINT` with values from the previous step.  By default the sample uses Entra identity (user identity and mananaged identity) so it is secretless.
+1. Replace the placeholder values like `OPENAI_ENDPOINT` with values from the previous step found in the `.azure` folder.  By default the sample uses Entra identity (user identity and mananaged identity) so it is secretless.
 
+Python:
 ```json
 {
   "IsEncrypted": false,
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "python",
+    "COSMOS_CONNECTION__accountEndpoint": "https://{my-cosmos-account}.documents.azure.com:443/",
     "COSMOS_DATABASE_NAME": "{database-name}",
     "COSMOS_CONTAINER_NAME": "{container-name}",
+    "COSMOS_OUTPUT_CONTAINER_NAME": "{container-name}",  
     "COSMOS_VECTOR_PROPERTY": "{vector-property-name}",
     "COSMOS_HASH_PROPERTY": "{hash-property-name}",
     "COSMOS_PROPERTY_TO_EMBED": "{property-to-generate-vectors-for}",
-    "COSMOS_CONNECTION": "{my-cosmos-connection-string}",
     "OPENAI_ENDPOINT": "https://{my-open-ai-account}.openai.azure.com/",
-    "OPENAI_KEY": "{my-open-ai-key}",
+    "OPENAI_DEPLOYMENT_NAME": "{my-embeddings-deployment-name}",
+    "OPENAI_DIMENSIONS": "1536"
+  }
+}
+```
+
+C# (.NET):
+```json
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "COSMOS_CONNECTION__accountEndpoint": "https://{my-cosmos-account}.documents.azure.com:443/",
+    "COSMOS_DATABASE_NAME": "{database-name}",
+    "COSMOS_CONTAINER_NAME": "{container-name}",
+    "COSMOS_OUTPUT_CONTAINER_NAME": "{container-name}",  
+    "COSMOS_VECTOR_PROPERTY": "{vector-property-name}",
+    "COSMOS_HASH_PROPERTY": "{hash-property-name}",
+    "COSMOS_PROPERTY_TO_EMBED": "{property-to-generate-vectors-for}",
+    "OPENAI_ENDPOINT": "https://{my-open-ai-account}.openai.azure.com/",
     "OPENAI_DEPLOYMENT_NAME": "{my-embeddings-deployment-name}",
     "OPENAI_DIMENSIONS": "1536"
   }
@@ -70,4 +78,16 @@ OPENAI_ENDPOINT: "https://{my-open-ai-account}.openai.azure.com/"
 
 - F5
 - Open a browser and navigate to the container in Cosmos Data Explorer
-- Create a new document and save.
+- Create a new document and save.      """
+
+The expected document/item has at least these 3 properties, and note that 'text' 
+is the property that gets embedded.
+
+Example document:
+```json
+{
+   "id": "cosmosdb_overview_1",
+   "customerId": "1",
+   "text": "Azure Cosmos DB is a fully managed NoSQL, relational, and vector database. It offers single-digit millisecond response times, automatic and instant scalability, along with guaranteed speed at any scale. Business continuity is assured with SLA-backed availability and enterprise-grade security."
+}
+```

--- a/csharp/CosmosEmbeddingGenerator.cs
+++ b/csharp/CosmosEmbeddingGenerator.cs
@@ -41,6 +41,23 @@ namespace CosmosEmbeddingGenerator
 
         }
 
+        /// <summary>
+        /// This function listens for changes to new or existing CosmosDb documents/items,
+        /// and updates them in place with vector embeddings.
+        ///
+        /// The expected document/item has at least these 3 properties, and note that 'text' 
+        /// is the property that gets embedded.
+        ///
+        /// Example document:
+        /// {
+        ///     "id": "cosmosdb_overview_1",
+        ///     "customerId": "1",
+        ///     "text": "Azure Cosmos DB is a fully managed NoSQL, relational, and vector database. It offers single-digit millisecond response times, automatic and instant scalability, along with guaranteed speed at any scale. Business continuity is assured with SLA-backed availability and enterprise-grade security."
+        /// }
+        /// </summary>
+        /// <param name="input">The list of documents that were modified in the CosmosDB container.</param>
+        /// <param name="context">The execution context of the Azure Function.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the updated documents with vector embeddings.</returns>
         [Function(nameof(CosmosEmbeddingGeneratorFunction))]
         [CosmosDBOutput(
             databaseName: "%COSMOS_DATABASE_NAME%",

--- a/csharp/CosmosEmbeddingGenerator.csproj
+++ b/csharp/CosmosEmbeddingGenerator.csproj
@@ -11,8 +11,8 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
     <!-- Application Insights isn't enabled by default. See https://aka.ms/AAt8mw4. -->
-    <!-- <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" /> -->
-    <!-- <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" /> -->
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.CosmosDB" Version="4.11.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.0" />

--- a/csharp/Program.cs
+++ b/csharp/Program.cs
@@ -1,10 +1,12 @@
 using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 
 var builder = FunctionsApplication.CreateBuilder(args);
 
-builder.ConfigureFunctionsWebApplication();
+// Configure Application Insights
+builder.Services.AddApplicationInsightsTelemetryWorkerService();
 
+builder.ConfigureFunctionsWebApplication();
 
 builder.Build().Run();

--- a/csharp/infra/main.bicep
+++ b/csharp/infra/main.bicep
@@ -53,7 +53,7 @@ var deploymentStorageContainerName = 'app-package-container'
 var cosmosSettings = {
   database: 'embeddings-generator-db'
   container: 'customer'
-  outputcontainer: 'customer-embeddings'
+  outputcontainer: 'customer'  // currently we output embeddings to the same container and same document/item
   partitionKey: 'customerId'
   vectorProperty: 'vectors'
   hashProperty: 'hash'
@@ -195,6 +195,7 @@ module security 'app/security.bicep' = {
 output COSMOS_CONNECTION__accountEndpoint string = database.outputs.endpoint
 output COSMOS_DATABASE_NAME string = cosmosSettings.database
 output COSMOS_CONTAINER_NAME string = cosmosSettings.container
+output COSMOS_OUTPUT_CONTAINER_NAME string = cosmosSettings.outputcontainer
 output COSMOS_VECTOR_PROPERTY string = cosmosSettings.vectorProperty
 output COSMOS_HASH_PROPERTY string = cosmosSettings.hashProperty
 output COSMOS_PROPERTY_TO_EMBED string = cosmosSettings.PropertyToEmbed

--- a/csharp/sample.settings.json
+++ b/csharp/sample.settings.json
@@ -1,16 +1,17 @@
 {
-    "IsEncrypted": false,
-    "Values": {
-      "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-      "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-      "COSMOS_CONNECTION__accountEndpoint": "https://{my-cosmos-account}.documents.azure.com:443/",
-      "COSMOS_DATABASE_NAME": "{database-name}",
-      "COSMOS_CONTAINER_NAME": "{container-name}",
-      "COSMOS_VECTOR_PROPERTY": "{vector-property-name}",
-      "COSMOS_HASH_PROPERTY": "{hash-property-name}",
-      "COSMOS_PROPERTY_TO_EMBED": "{property-to-generate-vectors-for}",
-      "OPENAI_ENDPOINT": "https://{my-open-ai-account}.openai.azure.com/",
-      "OPENAI_DEPLOYMENT_NAME": "{my-embeddings-deployment-name}",
-      "OPENAI_DIMENSIONS": "1536"
-    }
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "COSMOS_CONNECTION__accountEndpoint": "https://{my-cosmos-account}.documents.azure.com:443/",
+    "COSMOS_DATABASE_NAME": "{database-name}",
+    "COSMOS_CONTAINER_NAME": "{container-name}",
+    "COSMOS_OUTPUT_CONTAINER_NAME": "{container-name}",  
+    "COSMOS_VECTOR_PROPERTY": "{vector-property-name}",
+    "COSMOS_HASH_PROPERTY": "{hash-property-name}",
+    "COSMOS_PROPERTY_TO_EMBED": "{property-to-generate-vectors-for}",
+    "OPENAI_ENDPOINT": "https://{my-open-ai-account}.openai.azure.com/",
+    "OPENAI_DEPLOYMENT_NAME": "{my-embeddings-deployment-name}",
+    "OPENAI_DIMENSIONS": "1536"
   }
+}

--- a/python/function_app.py
+++ b/python/function_app.py
@@ -31,6 +31,7 @@ OPENAI_CLIENT = AzureOpenAI(
 # Initialize the function app
 app = func.FunctionApp()
 
+
 @app.function_name(name="cosmos-embedding-generator")
 @app.cosmos_db_output(
     arg_name="output", 
@@ -45,6 +46,20 @@ app = func.FunctionApp()
     lease_container_name="leases",
     create_lease_container_if_not_exists=True)
 async def cosmos_embedding_generator(input: func.DocumentList, output: func.Out[func.Document]):
+    """
+    This function listens for changes to new or existing CosmosDb documents/items,
+    and updates them in place with vector embeddings.
+
+    The expected document/item has at least these 3 properties, and note that 'text' 
+    is the property that gets embedded.
+
+    Example document:
+    {
+        "id": "cosmosdb_overview_1",
+        "customerId": "1",
+        "text": "Azure Cosmos DB is a fully managed NoSQL, relational, and vector database. It offers single-digit millisecond response times, automatic and instant scalability, along with guaranteed speed at any scale. Business continuity is assured with SLA-backed availability and enterprise-grade security."
+    }
+    """
 
     if input:
         logging.info('Documents modified: %s', len(input))

--- a/python/infra/main.bicep
+++ b/python/infra/main.bicep
@@ -195,6 +195,7 @@ module security 'app/security.bicep' = {
 output COSMOS_CONNECTION__accountEndpoint string = database.outputs.endpoint
 output COSMOS_DATABASE_NAME string = cosmosSettings.database
 output COSMOS_CONTAINER_NAME string = cosmosSettings.container
+output COSMOS_OUTPUT_CONTAINER_NAME string = cosmosSettings.outputcontainer
 output COSMOS_VECTOR_PROPERTY string = cosmosSettings.vectorProperty
 output COSMOS_HASH_PROPERTY string = cosmosSettings.hashProperty
 output COSMOS_PROPERTY_TO_EMBED string = cosmosSettings.PropertyToEmbed

--- a/python/infra/main.bicep
+++ b/python/infra/main.bicep
@@ -53,7 +53,7 @@ var deploymentStorageContainerName = 'app-package-container'
 var cosmosSettings = {
   database: 'embeddings-generator-db'
   container: 'customer'
-  outputcontainer: 'customer-embeddings'
+  outputcontainer: 'customer'  // currently we output embeddings to the same container and same document/item
   partitionKey: 'customerId'
   vectorProperty: 'vectors'
   hashProperty: 'hash'

--- a/python/sample.settings.json
+++ b/python/sample.settings.json
@@ -6,6 +6,7 @@
     "COSMOS_CONNECTION__accountEndpoint": "https://{my-cosmos-account}.documents.azure.com:443/",
     "COSMOS_DATABASE_NAME": "{database-name}",
     "COSMOS_CONTAINER_NAME": "{container-name}",
+    "COSMOS_OUTPUT_CONTAINER_NAME": "{container-name}",  
     "COSMOS_VECTOR_PROPERTY": "{vector-property-name}",
     "COSMOS_HASH_PROPERTY": "{hash-property-name}",
     "COSMOS_PROPERTY_TO_EMBED": "{property-to-generate-vectors-for}",


### PR DESCRIPTION
- Updates all samples for local.settings.json to be aware of output container concept
- Still match input and output containers, so documents are updated in place
- updating readme for simplicity
- provide example of document to update, because people were forgetting to add text property
- re-enabled application insights in C#