### PR TITLE
fix leases

### DIFF
--- a/csharp/infra/app/database.bicep
+++ b/csharp/infra/app/database.bicep
@@ -95,6 +95,18 @@ module cosmosDbContainers '../core/database/cosmos-db/nosql/container.bicep' = [
   }
 ]
 
+module cosmosDbLeases '../core/database/cosmos-db/nosql/container.bicep' = {
+  name: 'cosmos-db-container-leases'
+  params: {
+    name: 'leases'
+    parentAccountName: cosmosDbAccount.outputs.name
+    parentDatabaseName: cosmosDbDatabase.outputs.name
+    tags: tags
+    setThroughput: false
+    partitionKeyPaths: ['/id']
+  }
+}
+
 output endpoint string = cosmosDbAccount.outputs.endpoint
 output accountName string = cosmosDbAccount.outputs.name
 output connectionString string = cosmosDbAccount.outputs.connectionString

--- a/python/infra/app/database.bicep
+++ b/python/infra/app/database.bicep
@@ -95,6 +95,18 @@ module cosmosDbContainers '../core/database/cosmos-db/nosql/container.bicep' = [
   }
 ]
 
+module cosmosDbLeases '../core/database/cosmos-db/nosql/container.bicep' = {
+  name: 'cosmos-db-container-leases'
+  params: {
+    name: 'leases'
+    parentAccountName: cosmosDbAccount.outputs.name
+    parentDatabaseName: cosmosDbDatabase.outputs.name
+    tags: tags
+    setThroughput: false
+    partitionKeyPaths: ['/id']
+  }
+}
+
 output endpoint string = cosmosDbAccount.outputs.endpoint
 output accountName string = cosmosDbAccount.outputs.name
 output connectionString string = cosmosDbAccount.outputs.connectionString


### PR DESCRIPTION
Update bicep deployment to included leases collection. This fixes an issue where generator wouldn't work because the azure function didn't have the rights to create the leases collection so would not generate embeddings